### PR TITLE
Ensure Aruba can be updated

### DIFF
--- a/features/execution_order.feature
+++ b/features/execution_order.feature
@@ -19,7 +19,6 @@ Feature: Execution order
           Hello World!
       """
 
-  @debug
   Scenario:
     Given a file named "hookfile.{{myextension}}" with:
       """

--- a/features/failing_transaction.feature
+++ b/features/failing_transaction.feature
@@ -19,7 +19,6 @@ Feature: Failing a transaction
           Hello World!
       """
 
-  @debug
   Scenario:
     Given a file named "hookfile.{{myextension}}" with:
       """

--- a/features/hook_handlers.feature
+++ b/features/hook_handlers.feature
@@ -19,7 +19,6 @@ Feature: Hook handlers
           Hello World!
       """
 
-  @debug
   Scenario:
     Given a file named "hookfile.{{myextension}}" with:
       """

--- a/features/multiple_hookfiles.feature
+++ b/features/multiple_hookfiles.feature
@@ -19,7 +19,6 @@ Feature: Multiple hook files with a glob
           Hello World!
       """
 
-  @debug
   Scenario:
     Given a file named "hookfile1.{{myextension}}" with:
       """


### PR DESCRIPTION
**When I** maintain a Dredd Hooks package 
**I want** the standard test suite that documents it to rely on up-to-date tools 
**So that** I can find help and documentation easily if needed 

See https://dredd.readthedocs.io/en/latest/hooks/
See also https://github.com/apiaryio/dredd-hooks-ruby/issues/26