### PR TITLE
Improve beginning of README and simplify package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# Dredd Cross Language Hooks Test Suite
+# Cross-Language Test Suite for Dredd Hooks
 
 [![Build Status](https://travis-ci.org/apiaryio/dredd-hooks-template.svg?branch=master)](https://travis-ci.org/apiaryio/dredd-hooks-template)
 
-Language agnostic CLI test suite for boilerplating [Dredd hooks][dredd] handler in new language written in [Aruba][aruba].
+Language-agnostic BDD test suite for boilerplating implementation of [Dredd][] [hooks][] handler for a new language. It tests the public interface of the hooks handler and ensures it will work as Dredd expects. It's written in [Gherkin][] and ran by [Aruba][].
 
-  [aruba]: https://github.com/cucumber/aruba
-  [dredd]: https://github.com/apiaryio/dredd
+  [Aruba]: https://github.com/cucumber/aruba
+  [Gherkin]: https://github.com/cucumber/cucumber/wiki/Gherkin
+  [Dredd]: https://github.com/apiaryio/dredd
+  [hooks]: https://dredd.readthedocs.io/en/latest/hooks/
 
 ## Usage
 
@@ -50,7 +52,7 @@ The feature files syntax is validated automatically. To perform the validation l
 npm install
 
 # Run the linter
-./node_modules/gherkin-lint/src/main.js features/
+npm test
 ```
 
 ## Examples

--- a/package.json
+++ b/package.json
@@ -1,31 +1,18 @@
 {
   "name": "dredd-hooks-template",
   "version": "1.0.0",
-  "description": "A meta-package to install the testing dependencies of the Dredd Hooks template test suite.",
-  "main": "",
-  "dependencies": {
+  "description": "A meta-package to install the testing dependencies of the Dredd Hooks template test suite",
+  "devDependencies": {
     "gherkin-lint": "^2.0.0"
   },
-  "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "gherkin-lint features/"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/apiaryio/dredd-hooks-template.git"
+    "url": "https://github.com/apiaryio/dredd-hooks-template"
   },
-  "keywords": [
-    "Dredd",
-    "hooks",
-    "Cucumber",
-    "test suite",
-    "Aruba"
-  ],
-  "author": "Apiary",
+  "author": "Apiary Czech Republic, s.r.o. <support@apiary.io>",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/apiaryio/dredd-hooks-template/issues"
-  },
-  "homepage": "https://github.com/apiaryio/dredd-hooks-template#readme",
   "private": true
 }


### PR DESCRIPTION
I (hopefully) improved the lead paragraph of the README and simplified `package.json`:

- I fixed the author (exact name of the company),
- moved the linter to `npm test`,
- made use of the `./node_modules/.bin/gherkin-lint` executable, which automatically works as `gherkin-lint` within `scripts` in `package.json`,
- stripped down the contents of the `package.json` to emphasise it's _meta_ nature (it's even [`private: true`](https://docs.npmjs.com/files/package.json#private), so...)

This is a continuation of changes started in https://github.com/apiaryio/dredd-hooks-template/pull/10 by @gonzalo-bulnes.