### PR TITLE
Unify what form of CLI options is used

### DIFF
--- a/features/execution_order.feature
+++ b/features/execution_order.feature
@@ -78,7 +78,7 @@ Feature: Execution order
       | variable                       | value      |
       | TEST_DREDD_HOOKS_HANDLER_ORDER | true       |
 
-    When I run `dredd ./apiary.apib http://localhost:4567 --server "ruby server.rb" --language dredd-hooks-{{mylanguage}} --hookfiles ./hookfile.{{myextension}}`
+    When I run `dredd ./apiary.apib http://localhost:4567 --server="ruby server.rb" --language="dredd-hooks-{{mylanguage}}" --hookfiles=./hookfile.{{myextension}}`
     Then the exit status should be 0
     And the output should contain:
       """

--- a/features/failing_transaction.feature
+++ b/features/failing_transaction.feature
@@ -34,7 +34,7 @@ Feature: Failing a transaction
       #}
       #
       """
-    When I run `dredd ./apiary.apib http://localhost:4567 --server "ruby server.rb" --language "dredd-hooks-{{mylanguage}}" --hookfiles ./hookfile.{{myextension}}`
+    When I run `dredd ./apiary.apib http://localhost:4567 --server="ruby server.rb" --language="dredd-hooks-{{mylanguage}}" --hookfiles=./hookfile.{{myextension}}`
     Then the exit status should be 1
     And the output should contain:
       """

--- a/features/hook_handlers.feature
+++ b/features/hook_handlers.feature
@@ -64,7 +64,7 @@ Feature: Hook handlers
 
       """
 
-    When I run `dredd ./apiary.apib http://localhost:4567 --server "ruby server.rb" --language dredd-hooks-{{mylanguage}} --hookfiles ./hookfile.{{myextension}}`
+    When I run `dredd ./apiary.apib http://localhost:4567 --server="ruby server.rb" --language="dredd-hooks-{{mylanguage}}" --hookfiles=./hookfile.{{myextension}}`
     Then the exit status should be 0
     And the output should contain:
       """

--- a/features/multiple_hookfiles.feature
+++ b/features/multiple_hookfiles.feature
@@ -59,7 +59,7 @@ Feature: Multiple hook files with a glob
       #}
       #
       """
-    When I run `dredd ./apiary.apib http://localhost:4567 --server "ruby server.rb" --language dredd-hooks-{{mylanguage}} --hookfiles ./hookfile1.{{myextension}} --hookfiles ./hookfile2.v --hookfiles ./hookfile_*.{{myextension}}`
+    When I run `dredd ./apiary.apib http://localhost:4567 --server="ruby server.rb" --language="dredd-hooks-{{mylanguage}}" --hookfiles=./hookfile1.{{myextension}} --hookfiles=./hookfile2.v --hookfiles=./hookfile_*.{{myextension}}`
     Then the exit status should be 0
     And the output should contain:
       """


### PR DESCRIPTION
- Always use double quotes around name of the hook handler (taken from Python hooks)
- Always use `--option=<value>` format for options (that's what AFAIK follows the original UNIX conventions and what I'd like to use consistently across all Dredd-related projects)