### PR TITLE
Add test for configurable port

### DIFF
--- a/features/configurable_port.feature
+++ b/features/configurable_port.feature
@@ -1,0 +1,43 @@
+Feature: Configurable port
+
+  Background:
+    Given I have "dredd-hooks-php" command installed
+    And I have "dredd" command installed
+    And a file named "server.rb" with:
+      """
+      require 'sinatra'
+      get '/message' do
+        "Hello World!\n\n"
+      end
+      """
+
+    And a file named "apiary.apib" with:
+      """
+      # My Api
+      ## GET /message
+      + Response 200 (text/html;charset=utf-8)
+          Hello World!
+      """
+
+  @announce
+  Scenario:
+    Given a file named "hookfile/.{{myextension}}" with:
+      """
+      ## So, replace following pseudo code with yours:
+      #
+      #require 'mylanguagehooks'
+      #
+      #key = 'hooks_modifications'
+      #
+      #before("/message > GET") { |transaction|
+      #  puts 'listening on different port'
+      #}
+      """
+
+    When I run `dredd ./apiary.apib http://localhost:4567 --hooks-worker-handler-port 61325 --server "ruby server.rb" --language "dredd-hooks-{{mylanguage}}" --hookfiles ./hookfile.{{myextension}}`
+    Then the exit status should be 0
+    Then the output should contain:
+      """
+      listening on different port
+      """
+


### PR DESCRIPTION
This is to address #11.

I already have this working for the php hooks based on a dredd change I made to pass the port to the hooks server command. (will update with link once its up).

## Todo
- [ ] Figure out what flag should be used for the port (php hooks already use --port, see [here](https://github.com/ddelnano/dredd-hooks-php/blob/master/bin/dredd-hooks-php#L26-L31))
- [ ] Add all hook server implementations with fix
- [ ] Figure out rollout plan.

I am assuming my dredd PR will need some work since it was the quickest change just to see this test work locally on my machine.  The change I made will cause problems with backwards compatibility (for instance @w-vi mentioned that the python hooks treat all arguments as filenames).  So atleast just wanted to get this rolling and hear feedback.  Another flag that is not used but can be provided is the `--hooks-worker-handler-host` so maybe we should include that change in this PR as well.