### PR TITLE
Handle dredd path in steps.js

### DIFF
--- a/cli/copyFeatures.js
+++ b/cli/copyFeatures.js
@@ -5,20 +5,14 @@ const glob = require('glob');
 
 /**
  * Copies all '*.feature' files from the 'srcDir' directory to the 'dstDir'
- * directory, allowing for a transformation of the file basename and
- * the content on the way using the 'transform()' function
+ * directory, allowing for a transformation of the file basename on the way
+ * using the 'modifyBasename()' function
  */
-module.exports = function copyFeatures(srcDir, dstDir, transform) {
+module.exports = function copyFeatures(srcDir, dstDir, modifyBasename = basename => basename) {
   glob.sync(path.join(srcDir, '*.feature')).forEach((featureSrcPath) => {
-    const featureSrcContent = fs.readFileSync(featureSrcPath, { encoding: 'utf-8' });
-    const {
-      basename: featureBasename,
-      content: featureContent,
-    } = transform({
-      basename: path.basename(featureSrcPath),
-      content: featureSrcContent,
-    });
-    const featurePath = path.join(dstDir, featureBasename);
+    const featureContent = fs.readFileSync(featureSrcPath, { encoding: 'utf-8' });
+    const featureBasename = path.basename(featureSrcPath);
+    const featurePath = path.join(dstDir, modifyBasename(featureBasename));
     fs.writeFileSync(featurePath, featureContent, { encoding: 'utf-8' });
   });
 }

--- a/cli/copyFeatures.js
+++ b/cli/copyFeatures.js
@@ -6,13 +6,13 @@ const glob = require('glob');
 /**
  * Copies all '*.feature' files from the 'srcDir' directory to the 'dstDir'
  * directory, allowing for a transformation of the file basename on the way
- * using the 'modifyBasename()' function
+ * using the 'transformBasename()' function
  */
-module.exports = function copyFeatures(srcDir, dstDir, modifyBasename = basename => basename) {
+module.exports = function copyFeatures(srcDir, dstDir, transformBasename = basename => basename) {
   glob.sync(path.join(srcDir, '*.feature')).forEach((featureSrcPath) => {
     const featureContent = fs.readFileSync(featureSrcPath, { encoding: 'utf-8' });
     const featureBasename = path.basename(featureSrcPath);
-    const featurePath = path.join(dstDir, modifyBasename(featureBasename));
+    const featurePath = path.join(dstDir, transformBasename(featureBasename));
     fs.writeFileSync(featurePath, featureContent, { encoding: 'utf-8' });
   });
 }

--- a/cli/index.js
+++ b/cli/index.js
@@ -5,7 +5,6 @@ const path = require('path');
 
 const run = require('./run');
 const copyFeatures = require('./copyFeatures');
-const replaceDredd = require('./replaceDredd');
 
 
 PROJECT_DIR = process.cwd();
@@ -16,7 +15,6 @@ FEATURES_DIR = path.join(PROJECT_DIR, 'features');
 STEPS_DIR = path.join(FEATURES_SRC_DIR, 'support');
 
 NODE_BIN = process.execPath;
-DREDD_BIN = path.join(NODE_MODULES_DIR, '.bin', 'dredd');
 CUCUMBER_BIN = path.join(NODE_MODULES_DIR, '.bin', 'cucumber-js');
 
 
@@ -24,14 +22,8 @@ function init() {
   // create a 'features' directory in the project we're initializing
   fs.mkdirSync(FEATURES_DIR);
 
-  // copy '*.feature' files from the template to the project, process each
-  // file so it references the right Dredd executable
-  copyFeatures(FEATURES_SRC_DIR, FEATURES_DIR, ({ basename, content }) => (
-    {
-      basename,
-      content: replaceDredd(content, DREDD_BIN),
-    }
-  ));
+  // copy '*.feature' files from the template to the project
+  copyFeatures(FEATURES_SRC_DIR, FEATURES_DIR);
 }
 
 
@@ -68,12 +60,7 @@ function upgrade() {
   // copy '*.feature' files from the upgraded 'dredd-hooks-template' package
   // to the project, but don't overwrite the existing feature files, add these
   // as new ones, suffixed with the 'dredd-hooks-template' version
-  copyFeatures(FEATURES_SRC_DIR, FEATURES_DIR, ({ basename, content }) => (
-    {
-      basename: `${basename}~${version}`,
-      content: replaceDredd(content, DREDD_BIN),
-    }
-  ));
+  copyFeatures(FEATURES_SRC_DIR, FEATURES_DIR, basename => `${basename}~${version}`);
 }
 
 

--- a/cli/replaceDredd.js
+++ b/cli/replaceDredd.js
@@ -1,9 +1,0 @@
-/**
- * Replaces mentions of the 'dredd' command in given '*.feature' file
- * content with a specific path to Dredd executable
- */
-module.exports = function replaceDredd(text, dreddBin) {
-  return text
-    .replace(/I have "dredd"/g, `I have "${dreddBin}"`)
-    .replace(/I run `dredd /g, `I run \`${dreddBin} `);
-};

--- a/features/support/steps.js
+++ b/features/support/steps.js
@@ -9,6 +9,8 @@ const which = require('which');
 const kill = require('tree-kill');
 const { Given, When, Then, Before, After } = require('cucumber');
 
+DREDD_BIN = path.join(process.cwd(), 'node_modules', '.bin', 'dredd');
+
 
 Before(function () {
   this.dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dredd-hooks-template-'));
@@ -23,7 +25,10 @@ After(async function () {
 });
 
 
-Given(/^I have "([^"]+)" command installed$/, function (command) {
+Given(/^I have "([^"]+)" command installed$/, function (match) {
+  const command = match === 'dredd'
+    ? DREDD_BIN
+    : match;
   which.sync(command); // throws if the command is not found
 });
 
@@ -36,7 +41,10 @@ Given(/^I set the environment variables to:$/, function (env) {
 });
 
 
-When(/^I run `([^`]+)`$/, function (command) {
+When(/^I run `([^`]+)`$/, function (match) {
+  const command = match.startsWith('dredd ')
+    ? match.replace(/^dredd/, DREDD_BIN)
+    : match;
   this.proc = childProcess.spawnSync(command, [], {
     shell: true,
     cwd: this.dir,

--- a/features/support/steps.js
+++ b/features/support/steps.js
@@ -42,9 +42,7 @@ Given(/^I set the environment variables to:$/, function (env) {
 
 
 When(/^I run `([^`]+)`$/, function (match) {
-  const command = match.startsWith('dredd ')
-    ? match.replace(/^dredd/, DREDD_BIN)
-    : match;
+  const command = match.replace(/^dredd(?= )/, DREDD_BIN);
   this.proc = childProcess.spawnSync(command, [], {
     shell: true,
     cwd: this.dir,


### PR DESCRIPTION
Previously, the path to Dredd executable was set when the feature files got copied over from the template to the project. I found a simpler solution, basically by adding two lines to steps.js.

Close https://github.com/apiaryio/dredd-hooks-template/issues/44, close https://github.com/apiaryio/dredd-hooks-template/issues/3