### PR TITLE
Use --save-exact to prevent carets or tildas

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To use the test suite, first read the docs about [how to create a new hooks hand
     }
     ```
 
-1.  Run `npm install dredd-hooks-template --save-dev` to install and declare this test suite as your development dependency.
+1.  Run `npm install dredd-hooks-template --save-dev --save-exact` to install and declare this test suite as your development dependency.
 1.  Run `npx dredd-hooks-template init` to get a copy of the test suite in the `./features` directory.
 1.  Open the feature files in `./features/*.feature` and in all of them
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -58,7 +58,7 @@ function upgrade() {
 
   // upgrade the package
   const pkg = `dredd-hooks-template@${version}`;
-  run('npm', ['install', pkg, '--save-dev'], { cwd: PROJECT_DIR });
+  run('npm', ['install', pkg, '--save-dev', '--save-exact'], { cwd: PROJECT_DIR });
 
   // copy '*.feature' files from the upgraded 'dredd-hooks-template' package
   // to the project, but don't overwrite the existing feature files, add these


### PR DESCRIPTION
It's because then the rest gets much easier. We want a specific version, not a range.