### PR TITLE
Remove the word 'glob'

### DIFF
--- a/features/multiple_hookfiles.feature
+++ b/features/multiple_hookfiles.feature
@@ -1,4 +1,4 @@
-Feature: Multiple hook files with a glob
+Feature: Multiple hook files
 
   Background:
     Given I have Dredd installed


### PR DESCRIPTION
After apiaryio/dredd#680 got implemented, the template should not force the hook handlers to implement their own globbing anymore. However, the template does not force it explicitly. It calls Dredd with a glob pattern passed to --hookfiles, and implies nothing about where the glob gets resolved. This change removes the word 'glob' from the feature name as the feature should only represent 'multiple hook files' to the hooks handler creators. The docs http://dredd.org/en/latest/hooks/new-language.html now document that implementing glob is not necessary.

Close #22