### PR TITLE
Support the --port option

### DIFF
--- a/features/support/steps.js
+++ b/features/support/steps.js
@@ -132,10 +132,10 @@ Then('the output should contain:', function step(output) {
   expect(this.proc.stdout.toString() + this.proc.stderr.toString()).to.contain(output);
 });
 
-Then('it should start listening on localhost port {int}', async function step(port) {
+Then('it should start listening on {string} port {int}', async function step(host, port) {
   this.socket = new net.Socket();
   const connect = util.promisify(this.socket.connect.bind(this.socket));
-  await connect(port, '127.0.0.1'); // throws if there's an issue
+  await connect(port, host); // throws if there's an issue
   this.socket.end();
 });
 

--- a/features/tcp_messages.feature
+++ b/features/tcp_messages.feature
@@ -1,0 +1,61 @@
+Feature: TCP messages
+
+  Scenario: Message exchange for event beforeEach
+    Given I run `{{my-executable-path}}` interactively
+    When I wait for output to contain "Starting"
+    And I connect to the server
+    And I send a JSON message to the socket:
+      """
+      {"event": "beforeEach", "uuid": "1234-abcd", "data": {"key":"value"}}
+      """
+    And I send a newline character as a message delimiter to the socket
+    Then I should receive the same response
+    And I should be able to gracefully disconnect
+
+  Scenario: Message exchange for event beforeEachValidation
+    Given I run `{{my-executable-path}}` interactively
+    When I wait for output to contain "Starting"
+    And I connect to the server
+    And I send a JSON message to the socket:
+      """
+      {"event": "beforeEachValidation", "uuid": "2234-abcd", "data": {"key":"value"}}
+      """
+    And I send a newline character as a message delimiter to the socket
+    Then I should receive the same response
+    And I should be able to gracefully disconnect
+
+  Scenario: Message exchange for event afterEach
+    Given I run `{{my-executable-path}}` interactively
+    When I wait for output to contain "Starting"
+    And I connect to the server
+    And I send a JSON message to the socket:
+      """
+      {"event": "afterEach", "uuid": "3234-abcd", "data": {"key":"value"}}
+      """
+    And I send a newline character as a message delimiter to the socket
+    Then I should receive the same response
+    And I should be able to gracefully disconnect
+
+  Scenario: Message exchange for event beforeAll
+    Given I run `{{my-executable-path}}` interactively
+    When I wait for output to contain "Starting"
+    And I connect to the server
+    And I send a JSON message to the socket:
+      """
+      {"event": "beforeAll", "uuid": "4234-abcd", "data": {"key":"value"}}
+      """
+    And I send a newline character as a message delimiter to the socket
+    Then I should receive the same response
+    And I should be able to gracefully disconnect
+
+  Scenario: Message exchange for event afterAll
+    Given I run `{{my-executable-path}}` interactively
+    When I wait for output to contain "Starting"
+    And I connect to the server
+    And I send a JSON message to the socket:
+      """
+      {"event": "afterAll", "uuid": "5234-abcd", "data": {"key":"value"}}
+      """
+    And I send a newline character as a message delimiter to the socket
+    Then I should receive the same response
+    And I should be able to gracefully disconnect


### PR DESCRIPTION
This is a kick off to address the long-pending https://github.com/apiaryio/dredd-hooks-template/issues/11 and https://github.com/apiaryio/dredd-hooks-template/pull/17. Big thanks to @ddelnano for contributing the initial work and opening the discussion back in the days. I'm sorry this is taking so long to tackle, but as you can see in https://github.com/apiaryio/dredd/issues/917, it got stuck on various circular chicken-egg dependency issues.

**BREAKING CHANGE:** After this PR gets merged, it is going to be required that the hooks handler process is able to accept a `--port` option in addition to the list of hook files.